### PR TITLE
Simplified mongoose.connect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,7 @@ app.use(cors());
 app.use(bodyParser.json());
 
 mongoose
-  .connect(process.env.DB_URL, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  })
+  .connect(process.env.DB_URL)
   .then(() => {
     console.log("DB connected");
   })


### PR DESCRIPTION
Removed Deprecated Options:
useNewUrlParser: Removed because it's unnecessary in Mongoose versions compatible with MongoDB Node.js Driver 4.0.0 and above.
useUnifiedTopology: Similarly removed as it's also unnecessary with the modern driver.